### PR TITLE
Remove redundant check for unequal types in merge

### DIFF
--- a/src/GSExtended.user.js
+++ b/src/GSExtended.user.js
@@ -623,15 +623,8 @@ GSX = {
         
         GS.Models.ChatActivity.prototype.merge =  function(merge){
             return function(newChat){
-                if(this.get('type') === 'message'){
-                    if(GSX.settings.disableChatMerge){
-                        return false;
-                    }else{
-                        //fix GS bug !
-                        if(newChat.get('type') != 'message'){
-                            return false;
-                        }
-                    }
+                if(this.get('type') === 'message' && GSX.settings.disableChatMerge){
+                    return false;
                 }
                 return merge.apply(this,arguments);
             }


### PR DESCRIPTION
This was fixed over a week ago on Grooveshark so this check isn't needed. Thanks for highlighting the issue!
